### PR TITLE
Changed determined compilation to custom make

### DIFF
--- a/seminar_3/Makefile
+++ b/seminar_3/Makefile
@@ -8,17 +8,17 @@ IMPLDIR=implementations
 BNCHDIR=benchmark
 SHELL=/bin/bash
 
-$(IMPLTARGETS): build/% : implementations/%/lock.o build build/main.o
-	gcc -pthread build/main.o $(IMPLDIR)/$(@:build/%=%)/lock.o -o $@
+$(IMPLTARGETS): build/% : implementations/%/object build build/main.o
+	gcc -pthread build/main.o $(IMPLDIR)/$(@:build/%=%)/*.o -o $@
 
 build/main.o: $(BNCHDIR)/main.c
 	gcc -c -pthread -std=c99 $^ -o $@
 
-%lock.o: %lock.c
-	gcc -Wall -pedantic -c -static -Ibenchmark/ -shared -std=c99 $^ -o $@
+%object: %Makefile
+	make -s -C $* all
 
 build:
 	mkdir build/
 
 clean:
-	rm -rf build/ implementations/*/lock.o
+	rm -rf build/ implementations/*/*.o

--- a/seminar_3/implementations/dummy/Makefile
+++ b/seminar_3/implementations/dummy/Makefile
@@ -1,0 +1,4 @@
+CFLAGS = -Wall -pedantic -static -I ../../benchmark -shared -std=c99
+
+all: lock.c
+	gcc $(CFLAGS) -c $^ -o lock.o

--- a/seminar_3/implementations/filipp_tas/Makefile
+++ b/seminar_3/implementations/filipp_tas/Makefile
@@ -1,0 +1,4 @@
+CFLAGS = -Wall -pedantic -static -I ../../benchmark -shared -std=c99
+
+all: lock.c
+	gcc $(CFLAGS) -c $^ -o lock.o


### PR DESCRIPTION
Previously all implementations were built in the same way (in Makefile):
```Makefile
%lock.o: %lock.c
	gcc -Wall -pedantic -c -static -Ibenchmark/ -shared -std=c99 $^ -o $@
```
I changed it to
```Makefile
%object: %Makefile
	make -s -C $* object
```
to let students use their own Makefile for building their implementation